### PR TITLE
Update badges, bump version number, and switch to Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Angle Wrapper
 
+[![Python package](https://github.com/jbrodovsky/angle_wrapper/actions/workflows/python_project.yml/badge.svg)](https://github.com/jbrodovsky/angle_wrapper/actions/workflows/python_project.yml)
+
+[![release](https://github.com/jbrodovsky/angle_wrapper/actions/workflows/python-publish.yml/badge.svg)](https://github.com/jbrodovsky/angle_wrapper/actions/workflows/python-publish.yml)
+
 A simple Python only toolbox for wrapping angles to $\pm180^\circ$, $\left[0^\circ, 360^\circ\right]$, $\pm\pi$, or $\left[0,  2\pi\right]$. Wraps single values, tuples, lists, and other various iterable types that implement the `__iter__` attribute such as NumPy arrays and Pandas data series.
 
 To install: `pip install anglewrapper`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anglewrapper"
-version = "0.2.1"
-requires-python = ">=3.8"
+version = "0.2.2"
+requires-python = ">=3.9"
 description = "A package for wrapping angles in radians and degrees"
 authors = [{name="James Brodovsky"}]
 license = {file = "LICENSE"}


### PR DESCRIPTION
This pull request updates the badges in the README file, bumps the version number to 0.2.2, and switches the required Python version to 3.9.