### PR TITLE
Duplicate Python methods in C++ for practice and speed test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .venv
 *.egg-info
 *__pycache__
+venv

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/venv/**",
+                "/usr/include/python3.10"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A simple Python only toolbox for wrapping angles to $\pm180^\circ$, $\left[0^\ci
 To install: `pip install anglewrapper`
 
 To run:
-```
+
+```python
 from anglewrapper import wrap
 wrap.to_180(270)
 ```
@@ -27,4 +28,4 @@ This package is serving a few purposes:
   * Code formatting and linting
 * Continuous integration and continuous delivery to PyPI via GitHub Actions
 * Building, testing, and delivering Python packages
-* Some basic C++ practice and packaging it into libraries and/or Python packages 
+* Some basic C++ practice and packaging it into libraries and/or Python packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "anglewrapper"
-version = "0.1.1"
+version = "0.2.2"
 requires-python = ">=3.9"
 description = "A package for wrapping angles in radians and degrees"
 authors = [{name="James Brodovsky"}]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+"""Setup file for wrapfast."""
+
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import setup
+
+__version__ = "0.2.2"
+
+ext_modules = [
+    Pybind11Extension(
+        "anglewrapper.wrapfast",
+        ["src/anglewrapper/wrapfast.cpp"],
+        define_macros=[("VERSION_INFO", __version__)],
+    ),
+]
+
+setup(
+    name="anglewrapper.wrapfast",
+    version=__version__,
+    author="James Brodovsky",
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+    zip_safe=False,
+    python_requires=">=3.9",
+)

--- a/src/anglewrapper/wrapfast.cpp
+++ b/src/anglewrapper/wrapfast.cpp
@@ -1,0 +1,152 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <vector>
+
+namespace py = pybind11;
+
+/**
+ * @brief wraps the angle to +/- 180 degrees
+ * 
+ * @param angle 
+ * @return double 
+ */
+double to_180(double angle) {
+    if (angle > 180) {
+        return angle - 360;
+    } else if (angle < -180) {
+        return angle + 360;
+    } else {
+        return angle;
+    }
+}
+
+std::vector<double> to_180(std::vector<double> angles) {
+    for (double& angle : angles) {
+        angle = to_180(angle);
+    }
+    return angles;
+}
+
+/**
+ * @brief wraps the angle to +/- 180 degrees
+ * 
+ * @param angle 
+ * @return double 
+ */
+double to_360(double angle) {
+    if (angle > 360) {
+        return angle - 360;
+    } else if (angle < 0) {
+        return angle + 360;
+    } else {
+        return angle;
+    }
+}
+
+std::vector<double> to_360(std::vector<double> angles) {
+    for (double& angle : angles) {
+        angle = to_360(angle);
+    }
+    return angles;
+}
+
+/**
+ * @brief wraps the angle to +/- pi radians
+ * 
+ * @param angle
+ * @return double 
+ */
+
+double to_pi(double angle) {
+    if (angle > M_PI) {
+        return angle - 2*M_PI;
+    } else if (angle < -M_PI) {
+        return angle + 2*M_PI;
+    } else {
+        return angle;
+    }   
+}
+
+std::vector<double> to_pi(std::vector<double> angles) {
+    for (double& angle : angles) {
+        angle = to_pi(angle);
+    }
+    return angles;
+}
+
+/**
+ * @brief wraps the angle to +/- 2*pi radians
+ * 
+ * @param angle
+ * @return double 
+ */
+double to_2pi(double angle) {
+    if (angle > 2*M_PI) {
+        return angle - 2*M_PI;
+    } else if (angle < 0) {
+        return angle + 2*M_PI;
+    } else {
+        return angle;
+    }   
+}
+
+std::vector<double> to_2pi(std::vector<double> angles) {
+    for (double& angle : angles) {
+        angle = to_2pi(angle);
+    }
+    return angles;
+}
+
+
+PYBIND11_MODULE(wrapfast, m) {
+    m.doc() = "A fast module for wrapping angles to [-180, 180] and [-pi, pi], and [0, 360] and [0, 2pi]";
+
+    m.def("to_180", py::overload_cast<double>(&to_180), "A function that wraps an angle to [-180, 180]");
+    m.def("to_360", py::overload_cast<double>(&to_360), "A function that wraps an angle to [0, 360]");
+    m.def("to_pi", py::overload_cast<double>(&to_pi), "A function that wraps an angle to [-pi, pi]");
+    m.def("to_2pi", py::overload_cast<double>(&to_2pi), "A function that wraps an angle to [0, 2pi]");
+    m.def("to_180", py::overload_cast<std::vector<double>>(&to_180), "A function that wraps an interable of angles to [-180, 180]");
+    m.def("to_360", py::overload_cast<std::vector<double>>(&to_360), "A function that wraps an interable of angles to [0, 360]");
+    m.def("to_pi", py::overload_cast<std::vector<double>>(&to_pi), "A function that wraps an interable of angles to [-pi, pi]");
+    m.def("to_2pi", py::overload_cast<std::vector<double>>(&to_2pi), "A function that wraps an interable of angles to [0, 2pi]");
+    /**
+    m.def("to_180", [](py::array_t<double> input){
+        py::buffer_info buf_info = input.request();
+        double *ptr = static_cast<double *>(buf_info.ptr);
+        std::vector<double> angles(ptr, ptr + buf_info.size);
+        angles = to_2pi(angles);
+        py::array_t<double> result(buf_info.size, angles.data());
+        return result;
+    }
+    , "A function that wraps an interable of angles to [-180, 180]");
+    
+    m.def("to_360", [](py::array_t<double> input){
+        py::buffer_info buf_info = input.request();
+        double *ptr = static_cast<double *>(buf_info.ptr);
+        std::vector<double> angles(ptr, ptr + buf_info.size);
+        angles = to_360(angles);
+        py::array_t<double> result(buf_info.size, angles.data());
+        return result;
+    }
+    , "A function that wraps an interable of angles to [0, 360]");
+    m.def("to_pi", [](py::array_t<double> input){
+        py::buffer_info buf_info = input.request();
+        double *ptr = static_cast<double *>(buf_info.ptr);
+        std::vector<double> angles(ptr, ptr + buf_info.size);
+        angles = to_pi(angles);
+        py::array_t<double> result(buf_info.size, angles.data());
+        return result;
+    }
+    , "A function that wraps an interable of angles to [-pi, pi]");
+    m.def("to_2pi", [](py::array_t<double> input){
+        py::buffer_info buf_info = input.request();
+        double *ptr = static_cast<double *>(buf_info.ptr);
+        std::vector<double> angles(ptr, ptr + buf_info.size);
+        angles = to_2pi(angles);
+        py::array_t<double> result(buf_info.size, angles.data());
+        return result;
+    }
+    , "A function that wraps an interable of angles to [0, 2pi]");
+    */
+}

--- a/test_call.py
+++ b/test_call.py
@@ -1,0 +1,23 @@
+"""
+tester for anglewrapper
+"""
+from anglewrapper import wrap
+from anglewrapper import wrapfast
+
+import numpy as np
+
+
+def main():
+    """
+    This is a test function.
+    """
+    print("Hello World!")
+
+    print(wrap.to_180([1000, 200, 300]))
+    print(wrapfast.to_180(300))
+    print(wrapfast.to_180([1000, 200, 300]))
+    print(wrapfast.to_180(np.array([400, 200, 300])))
+
+
+if __name__ == "__main__":
+    main()

--- a/test_call.py
+++ b/test_call.py
@@ -16,7 +16,7 @@ def main():
     print(wrap.to_180([1000, 200, 300]))
     print(wrapfast.to_180(300))
     print(wrapfast.to_180([1000, 200, 300]))
-    print(wrapfast.to_180(np.array([400, 200, 300])))
+    # print(wrapfast.to_180(np.array([400, 200, 300])))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request duplicates the existing four Python methods in C++ for the purpose of practicing C++ programming, packaging C++ for Python, and conducting a simple speed test. The changes include adding the necessary C++ code files, updating the project configuration files, and adding a test script. This pull request addresses issue #9.